### PR TITLE
Case sensitive env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV DRUID_LOGLEVEL      '-'
 
 RUN apk add --update wget tar bash
 
-RUN mkdir -p /opt/druid
+RUN mkdir -p /opt
 
 RUN wget -q --no-check-certificate --no-cookies -O - \
     http://static.druid.io/artifacts/releases/druid-$DRUID_VERSION-bin.tar.gz | tar -xzf - -C /opt \

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ You can override *any* setting in `common.runtime.properties` and `runtime.prope
 
 For example, if you want to override the setting `druid.metadata.storage.connector.user` and set it to `DBUSER`, set the environment variable `DRUID_METADATA_STORAGE_CONNECTOR_USER=DBUSER`.
 
+If the `DRUID` at the beginning is not upper-cased, the case will be left alone. Thus:
+
+* `DRUID_METADATA_STORAGE_CONNECTOR_USER=DBUSER` will be converted to `druid.metadata.storage.connector.user=DBUSER`
+* `druid_metadata_storage_connector_connectURI=jdbc:postgresql://dbserver/db` will be converted to `druid.metadata.storage.connector.connectURI=jdbc:postgresql://dbserver/db`
+
 Authors
 =======
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,10 +36,14 @@ if [ "$DRUID_USE_CONTAINER_IP" != "-" ]; then
 fi
 
 # catch all environment vars that start with DRUID_ and set them to override druid.
-druidVars=$(env | awk -F= '/^DRUID_/ {
+ucDruidVars=$(env | awk -F= '/^DRUID_/ {
     gsub("_",".",$1)
     print "-D"tolower($1)"="$2
 }')
+lcDruidVars=$(env | awk -F= '/^druid_/ {
+    gsub("_",".",$1)
+    print "-D"$1"="$2
+}')
 
 
-java `cat /opt/druid/conf/druid/$1/jvm.config | xargs` ${druidVars} -cp /opt/druid/conf/druid/_common:/opt/druid/conf/druid/$1:/opt/druid/lib/* io.druid.cli.Main server $@
+java `cat /opt/druid/conf/druid/$1/jvm.config | xargs` ${ucDruidVars} ${lcDruidVars} -cp /opt/druid/conf/druid/_common:/opt/druid/conf/druid/$1:/opt/druid/lib/* io.druid.cli.Main server $@


### PR DESCRIPTION
Previously, env vars could not handle case-sensitive properties. For example, `druid.connectURI`. We would use env var `DRUID_CONNECTURI`, which would get converted to `druid.connecturi`, which is incorrect case and would be ignored.

This adds support for env vars that start with `druid_` which keep their case.