### PR TITLE
Simplify env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,22 @@
-Docker Druid
-================
+# Docker Druid
 
 Tags:
 
 - 0.9.2, 0.9, latest ([Dockerfile](https://github.com/deitch/docker-druid/blob/master/Dockerfile))
 
-What is Druid?
-==================
+## What is Druid?
 
 Druid is an open-source analytics data store designed for business intelligence (OLAP) queries on event data. Druid provides low latency (real-time) data ingestion, flexible data exploration, and fast data aggregation. Existing Druid deployments have scaled to trillions of events and petabytes of data. Druid is most commonly used to power user-facing analytic applications.
 
 
-How to use?
-===========
+## Running
 
 Druid being a complex system, the best way to get up and running with a cluster is to use the docker-compose file provided.
 
 Clone our public repository:
 
 ```
-git clone git@github.com:znly/docker-druid.git
+git clone git@github.com:deitch/docker-druid.git
 ```
 
 and run :
@@ -28,7 +25,7 @@ and run :
 docker-compose up
 ```
 
-The compose file is going to launch :
+The compose file will launch :
 
 - 1 [zookeeper](https://hub.docker.com/r/znly/zookeeper/) node
 - 1 postgres database
@@ -42,37 +39,32 @@ and the following druid services :
 
 The image contains the full druid distribution and use the default druid cli. If no command is provided the image will run as a broker.
 
-If you plan to use this image on your local machine, be carefull with the JVM heap spaces required by default (some services are launched with 15gb heap space).
+If you plan to use this image on your local machine, be careful with the JVM heap spaces required by default (some services are launched with 15gb heap space).
 
-The docker-compose file is setup to run on a macbook.
+## Configuration
 
-Documentation
-=============
+You can override *any* setting in `common.runtime.properties` and `runtime.properties` by setting an environment variable that begins with `druid_` and matches the property name, with `.` replaced by `_`.
 
-Work in progress
+For example, if you want to override the setting `druid.metadata.storage.connector.user` and set it to `DBUSER`, set the environment variable `druid_metadata_storage_connector_user=DBUSER`. All case is respected.
 
-Configuration
-=============
+Thus `druid_metadata_storage_connector_connectURI=jdbc:postgresql://dbSErver/db` will be converted to `druid.metadata.storage.connector.connectURI=jdbc:postgresql://dbSErver/db`
 
-Available environment options:
+In addition, certain environment variables have special properties. If unset, they use the defaults configured in `./conf/druid/`. If set, they override the properties.
 
-- `DRUID_XMX` '-'
-- `DRUID_XMS` '-'
-- `DRUID_NEWSIZE` '-'
-- `DRUID_MAXNEWSIZE` '-'
-- `DRUID_HOSTNAME` '-'
+* `DRUID_XMX`: `java -Xmx${DRUID_XMX}`
+* `DRUID_XMS`: `java -Xms${DRUID_XMS}`
+* `DRUID_NEWSIZE`: `java -XX:NewSize=${DRUID_NEWSIZE}``
+* `DRUID_MAXNEWSIZE` `java -XX:MaxNewSize=${DRUID_MAXNEWSIZE}``
+* `DRUID_USE_CONTAINER_IP`: if `true`, sets `druid.host` to be the IP of `eth0` inside the container.
+* `DRUID_HOSTNAME`: Convenience, equivalent to `druid_host=somename`
+* `DRUID_LOGLEVEL`: Convenience, equivalent to `java -Ddruid.emitter.logging.logLevel=${DRUID_LOGLEVEL}`.
 
-You can override *any* setting in `common.runtime.properties` and `runtime.properties` by setting an environment variable that matches the property name, converted to uppercase and with `.` replaced by `_`.
+Priority overrides: lowercase settings, e.g. `druid_host`, **always** override special variables, e.g. `DRUID_HOSTNAME`.
 
-For example, if you want to override the setting `druid.metadata.storage.connector.user` and set it to `DBUSER`, set the environment variable `DRUID_METADATA_STORAGE_CONNECTOR_USER=DBUSER`.
+Within the special variables, `DRUID_HOSTNAME` overrides `DRUID_USE_CONTAINER_IP`.
 
-If the `DRUID` at the beginning is not upper-cased, the case will be left alone. Thus:
-
-* `DRUID_METADATA_STORAGE_CONNECTOR_USER=DBUSER` will be converted to `druid.metadata.storage.connector.user=DBUSER`
-* `druid_metadata_storage_connector_connectURI=jdbc:postgresql://dbserver/db` will be converted to `druid.metadata.storage.connector.connectURI=jdbc:postgresql://dbserver/db`
-
-Authors
-=======
+## Authors
 
 - Jean-Baptiste DALIDO <jb@zen.ly>
 - Clément REY <clement@zen.ly>
+- Avi Deitcher <https://github.com/deitch>

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,16 +14,12 @@ if [ "$DRUID_XMS" != "-" ]; then
     sed -ri 's/Xms.*/Xms'${DRUID_XMS}'/g' /opt/druid/conf/druid/$1/jvm.config
 fi
 
-if [ "$DRUID_MAXNEWSIZE" != "-" ]; then
-    sed -ri 's/MaxNewSize=.*/MaxNewSize='${DRUID_MAXNEWSIZE}'/g' /opt/druid/conf/druid/$1/jvm.config
-fi
-
 if [ "$DRUID_NEWSIZE" != "-" ]; then
     sed -ri 's/NewSize=.*/NewSize='${DRUID_NEWSIZE}'/g' /opt/druid/conf/druid/$1/jvm.config
 fi
 
-if [ "$DRUID_HOSTNAME" != "-" ]; then
-    sed -ri 's/druid.host=.*/druid.host='${DRUID_HOSTNAME}'/g' /opt/druid/conf/druid/$1/runtime.properties
+if [ "$DRUID_MAXNEWSIZE" != "-" ]; then
+    sed -ri 's/MaxNewSize=.*/MaxNewSize='${DRUID_MAXNEWSIZE}'/g' /opt/druid/conf/druid/$1/jvm.config
 fi
 
 if [ "$DRUID_LOGLEVEL" != "-" ]; then
@@ -34,16 +30,16 @@ if [ "$DRUID_USE_CONTAINER_IP" != "-" ]; then
     ipaddress=`ip a|grep "global eth0"|awk '{print $2}'|awk -F '\/' '{print $1}'`
     sed -ri 's/druid.host=.*/druid.host='${ipaddress}'/g' /opt/druid/conf/druid/$1/runtime.properties
 fi
+if [ "$DRUID_HOSTNAME" != "-" ]; then
+    sed -ri 's/druid.host=.*/druid.host='${DRUID_HOSTNAME}'/g' /opt/druid/conf/druid/$1/runtime.properties
+fi
 
-# catch all environment vars that start with DRUID_ and set them to override druid.
-ucDruidVars=$(env | awk -F= '/^DRUID_/ {
-    gsub("_",".",$1)
-    print "-D"tolower($1)"="$2
-}')
-lcDruidVars=$(env | awk -F= '/^druid_/ {
+
+# catch all environment vars that start with druid_ and set them to override druid.
+druidVars=$(env | awk -F= '/^druid_/ {
     gsub("_",".",$1)
     print "-D"$1"="$2
 }')
 
 
-java `cat /opt/druid/conf/druid/$1/jvm.config | xargs` ${ucDruidVars} ${lcDruidVars} -cp /opt/druid/conf/druid/_common:/opt/druid/conf/druid/$1:/opt/druid/lib/* io.druid.cli.Main server $@
+java `cat /opt/druid/conf/druid/$1/jvm.config | xargs` ${druidVars} -cp /opt/druid/conf/druid/_common:/opt/druid/conf/druid/$1:/opt/druid/lib/* io.druid.cli.Main server $@


### PR DESCRIPTION
Separate how env vars are used:

1. `DRUID_` is special cases, does not get passed to `-D` for command-line but rather overrides the config files
2. `druid_` is set to be transformed to `-D` command-line options.
3. Update README to describe it
